### PR TITLE
feat(#5): Panel de gestión de zonas en el frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Cobertura incluida:
 ## Posibles mejoras
 
 - Histórico de alertas persistido en BD con consulta por rango de fechas
-- Panel de gestión de zonas en el frontend (añadir y eliminar desde la UI)
-- Spring Actuator para endpoints `/health` y `/metrics`
+- ✅ Panel de gestión de zonas en el frontend (añadir y eliminar desde la UI)
+- ✅ Spring Actuator para endpoints `/health` y `/metrics`
 - Simular intrusión con zona elegible desde el frontend
 - Autenticación con JWT para proteger los endpoints
 - MQTT para integración con sensores IoT reales en lugar de OpenSky

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import DroneMap from './components/DroneMap';
+import ConfirmModal from './components/ConfirmModal';
 import AlertPanel from './components/AlertPanel';
+import ZoneManagerModal from './components/ZoneManagerModal';
 import { useWebSocket } from './hooks/useWebSocket';
 
 export default function App() {
@@ -12,6 +14,8 @@ export default function App() {
   const [clearedAt, setClearedAt] = useState(null);
   const [mockAlerts, setMockAlerts] = useState([]);
   const [zoneFilter, setZoneFilter] = useState('ALL');
+  const [isZoneModalOpen, setIsZoneModalOpen] = useState(false);
+  const [zoneToDelete, setZoneToDelete] = useState(null);
 
   const { alerts: rawAlerts, connected } = useWebSocket();
   
@@ -63,6 +67,21 @@ export default function App() {
   }, []);
 
   const handleClearAlerts = () => setClearedAt(new Date());
+
+  const executeDeleteZone = async () => {
+    if (!zoneToDelete) return;
+    try {
+      await axios.delete(`http://localhost:8080/api/zones/${zoneToDelete.id}`);
+      setZones(prev => prev.filter(z => z.id !== zoneToDelete.id));
+      setZoneToDelete(null);
+    } catch (e) {
+      alert("Error al eliminar la zona.");
+    }
+  };
+
+  const handleZoneAdded = (newZone) => {
+    setZones(prev => [...prev, newZone]);
+  };
 
   // Acción para el botón de simular intrusión
   const handleSimulateIntrusion = () => {
@@ -153,7 +172,10 @@ export default function App() {
             
             <div style={{ background: 'white', padding: '20px', borderRadius: '8px', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
-                 <h3 style={{ margin: 0, fontSize: '16px', color: '#374151' }}>Zonas vigiladas</h3>
+                 <h3 style={{ margin: 0, fontSize: '16px', color: '#374151', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    Zonas vigiladas
+                    <button onClick={() => setIsZoneModalOpen(true)} style={{ background: '#e0e7ff', color: '#4338ca', border: 'none', borderRadius: '4px', padding: '2px 8px', fontSize: '12px', cursor: 'pointer', fontWeight: 'bold', transition: 'background 0.2s' }}>+ Añadir</button>
+                 </h3>
                  <select value={zoneFilter} onChange={e => setZoneFilter(e.target.value)} style={{ fontSize: '12px', background: '#f3f4f6', padding: '2px 8px', borderRadius: '12px', color: '#4b5563', border: 'none', cursor: 'pointer', outline: 'none' }}>
                    {zoneTypes.map(t => <option key={t} value={t}>{t === 'ALL' ? 'Todas las zonas' : t}</option>)}
                  </select>
@@ -167,9 +189,10 @@ export default function App() {
                        ? { bg: '#fff7ed', color: '#c2410c' }
                        : { bg: '#fee2e2', color: '#991b1b' };
                      return (
-                       <li key={z.id} style={{ fontSize: '14px', borderBottom: '1px solid #f3f4f6', paddingBottom: '10px', color: '#4b5563' }}>
-                         📍 <strong>{z.name}</strong>
-                         <span style={{ fontSize: '11px', background: badge.bg, color: badge.color, padding: '2px 6px', borderRadius: '4px', float: 'right' }}>{z.type}</span>
+                       <li key={z.id} style={{ display: 'flex', alignItems: 'center', fontSize: '14px', borderBottom: '1px solid #f3f4f6', paddingBottom: '10px', color: '#4b5563' }}>
+                         <span style={{ flex: 1, textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}>📍 <strong>{z.name}</strong></span>
+                         <span style={{ fontSize: '11px', background: badge.bg, color: badge.color, padding: '2px 6px', borderRadius: '4px', marginRight: '6px' }}>{z.type}</span>
+                         <button onClick={() => setZoneToDelete(z)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#ef4444', fontSize: '14px', padding: '0 4px', transition: 'transform 0.1s' }} title="Eliminar zona" onMouseOver={(e) => e.target.style.transform='scale(1.2)'} onMouseOut={(e) => e.target.style.transform='scale(1)'}>🗑️</button>
                        </li>
                      );
                    })
@@ -180,6 +203,20 @@ export default function App() {
             <AlertPanel alerts={alerts} />
          </div>
       </div>
+
+      <ZoneManagerModal 
+        isOpen={isZoneModalOpen} 
+        onClose={() => setIsZoneModalOpen(false)} 
+        onZoneAdded={handleZoneAdded} 
+      />
+
+      <ConfirmModal
+        isOpen={zoneToDelete !== null}
+        title="Eliminar Zona Restringida"
+        message={`¿Estás seguro de que quieres eliminar la zona "${zoneToDelete?.name}"? Esta acción no se puede deshacer y las alertas asociadas seguirán existiendo en el histórico, pero la vigilancia de coordenadas cesará de inmediato.`}
+        onCancel={() => setZoneToDelete(null)}
+        onConfirm={executeDeleteZone}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,0 +1,34 @@
+export default function ConfirmModal({ isOpen, title, message, onConfirm, onCancel }) {
+  if (!isOpen) return null;
+
+  return (
+    <div style={{
+      position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh',
+      background: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 9999
+    }}>
+      <div style={{
+        background: 'white', padding: '24px', borderRadius: '12px', width: '340px',
+        boxShadow: '0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05)',
+        fontFamily: 'system-ui, -apple-system, sans-serif'
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
+          <div style={{ width: '40px', height: '40px', borderRadius: '50%', background: '#fee2e2', display: 'flex', justifyContent: 'center', alignItems: 'center', color: '#dc2626', fontSize: '20px' }}>
+            ⚠️
+          </div>
+          <h2 style={{ margin: 0, fontSize: '18px', color: '#1f2937' }}>{title}</h2>
+        </div>
+        <p style={{ margin: '0 0 24px 0', fontSize: '14px', color: '#4b5563', lineHeight: '1.5' }}>
+          {message}
+        </p>
+        <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end' }}>
+          <button onClick={onCancel} style={{ padding: '8px 16px', background: '#f3f4f6', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '14px', fontWeight: '500', color: '#374151', transition: 'background 0.2s' }}>
+            Cancelar
+          </button>
+          <button onClick={onConfirm} style={{ padding: '8px 16px', background: '#dc2626', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '14px', fontWeight: '500', color: 'white', transition: 'background 0.2s' }}>
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ZoneManagerModal.jsx
+++ b/frontend/src/components/ZoneManagerModal.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function ZoneManagerModal({ isOpen, onClose, onZoneAdded }) {
+  const [formData, setFormData] = useState({
+    name: '',
+    type: 'AIRPORT',
+    latitude: '',
+    longitude: '',
+    radiusKm: ''
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  if (!isOpen) return null;
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const payload = {
+      name: formData.name,
+      type: formData.type,
+      latitude: parseFloat(formData.latitude),
+      longitude: parseFloat(formData.longitude),
+      radiusKm: parseFloat(formData.radiusKm)
+    };
+
+    if (isNaN(payload.latitude) || isNaN(payload.longitude) || isNaN(payload.radiusKm)) {
+      setError("Por favor, introduce coordenadas y radio numéricos válidos.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const resp = await axios.post('http://localhost:8080/api/zones', payload);
+      onZoneAdded(resp.data);
+      setFormData({ name: '', type: 'AIRPORT', latitude: '', longitude: '', radiusKm: '' });
+      onClose();
+    } catch (err) {
+      setError(err.response?.data?.message || 'Error al conectar con la API para crear la zona.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{
+      position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh',
+      background: 'rgba(0,0,0,0.4)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 9999
+    }}>
+      <div style={{
+        background: 'white', padding: '24px', borderRadius: '12px', width: '400px',
+        boxShadow: '0 4px 6px rgba(0,0,0,0.1), 0 1px 3px rgba(0,0,0,0.08)',
+        fontFamily: 'system-ui, -apple-system, sans-serif'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+          <h2 style={{ margin: 0, fontSize: '18px', color: '#1f2937' }}>Añadir Nueva Zona</h2>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', fontSize: '20px', cursor: 'pointer', color: '#9ca3af' }}>✖</button>
+        </div>
+
+        {error && (
+          <div style={{ background: '#fef2f2', color: '#ef4444', padding: '10px', borderRadius: '6px', fontSize: '13px', marginBottom: '16px' }}>
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          <div>
+            <label style={labelStyle}>Nombre de la zona</label>
+            <input name="name" value={formData.name} onChange={handleChange} required style={inputStyle} placeholder="ej: Aeropuerto Adolfo Suárez" />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Tipo de zona</label>
+            <select name="type" value={formData.type} onChange={handleChange} required style={{...inputStyle, background: 'white'}}>
+              <option value="AIRPORT">Aeropuerto (AIRPORT)</option>
+              <option value="MILITARY">Base Militar (MILITARY)</option>
+              <option value="NUCLEAR">Central Nuclear (NUCLEAR)</option>
+            </select>
+          </div>
+
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <div style={{ flex: 1 }}>
+              <label style={labelStyle}>Latitud</label>
+              <input name="latitude" type="number" step="any" value={formData.latitude} onChange={handleChange} required style={inputStyle} placeholder="40.4983" />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={labelStyle}>Longitud</label>
+              <input name="longitude" type="number" step="any" value={formData.longitude} onChange={handleChange} required style={inputStyle} placeholder="-3.5676" />
+            </div>
+          </div>
+
+          <div>
+            <label style={labelStyle}>Radio de alcance (km)</label>
+            <input name="radiusKm" type="number" step="0.1" value={formData.radiusKm} onChange={handleChange} required style={inputStyle} placeholder="5.0" />
+          </div>
+
+          <div style={{ display: 'flex', gap: '12px', marginTop: '10px' }}>
+            <button type="button" onClick={onClose} style={{ ...btnStyle, background: '#f3f4f6', color: '#4b5563', flex: 1 }}>Cancelar</button>
+            <button type="submit" disabled={loading} style={{ ...btnStyle, background: '#3b82f6', color: 'white', flex: 1 }}>
+              {loading ? 'Guardando...' : 'Guardar Zona'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle = {
+  display: 'block',
+  fontSize: '12px',
+  fontWeight: '600',
+  color: '#4b5563',
+  marginBottom: '4px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em'
+};
+
+const inputStyle = {
+  width: '100%',
+  padding: '8px 12px',
+  borderRadius: '6px',
+  border: '1px solid #d1d5db',
+  fontSize: '14px',
+  boxSizing: 'border-box'
+};
+
+const btnStyle = {
+  padding: '10px 14px',
+  border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontSize: '14px',
+  fontWeight: '600',
+  transition: 'opacity 0.2s'
+};


### PR DESCRIPTION
## Cambios
- Creado componente Modal customizado para poder añadir nuevas zonas restrictivas.
- Añadidos botones para eliminar zonas integrados sutilmente junto a cada nombre de zona.
- Reemplazada la fea alerta nativa ('window.confirm') por un modal UI elegante y superpuesto de advertencia.
- El README.md se ha actualizado marcando las tareas 5 y 6 como completadas.

Closes #5